### PR TITLE
Cleaned up package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,7 @@ Then, from the root, run
 
 ```sh
 > npm install
-> npm install -g gulp
 ```
-
-After all the dependencies are installed, run
-
-```sh
-> gulp
-```
-
-to create the `build` directory.
 
 To then watch for any file updates, run
 
@@ -30,9 +21,6 @@ In a second terminal, run
 ```sh
 > npm start
 ```
-
-to serve the `build` directory on `http://localhost:8080/`.
-
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "3D Einsteinian gravity simulator.",
   "main": "src/js/main.js",
   "scripts": {
-    "start": "cd build && http-server",
+    "install": "gulp",
+    "start": "http-server build/ -o",
     "debug": "cd src && wzrd js/main.js:js/app.min.js",
-    "test": "cd src/test && wzrd phystest.js"
+    "test": "wzrd src/test/phystest.js"
   },
   "repository": {
     "type": "git",
@@ -33,5 +34,7 @@
     "vinyl-source-stream": "^1.1.0",
     "wzrd": "^1.3.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "three-orbit-controls": "^71.1.0"
+  }
 }


### PR DESCRIPTION
I cleaned up some of the scripts in `package.json`.

Also updated `readme` to reflect these changes.

Changes:

1. Added `three-orbit-controls` to deps
2. removed `cd` calls from the `start` script
3. `gulp` gets called post `npm install` since you need to do it anyway
4. Made `http-server` simply serve the `build/` folder and it will open the browser automagically

It might be worth it to look into `budo` as a replacement for `wzrd`. Since `wzrd` is being used for dev purposes `budo`'s fast autoreload watching will make development a lot more enjoyable.

https://www.npmjs.com/package/budo

Looks cool so far btw. Not sure what it's going to be but looks cool.